### PR TITLE
supporting the result of universal enrichment analyzer by setting orgDb to NULL

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.github$
+^Makefile$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Encoding: UTF-8
 Depends:
     R (>= 4.2.0)
 Imports: ggplot2, magrittr, graphite, ggraph, igraph, bnlearn (>= 4.7), patchwork, org.Hs.eg.db, clusterProfiler, utils, enrichplot, reshape2, ggforce, dplyr, tidyr, stringr, depmap, ExperimentHub, Rmpfr, graphlayouts, BiocFileCache, ggdist, purrr, pvclust
-Suggests: knitr, arules, concaveman, ReactomePA, bnviewer, DESeq2, GEOquery, rmarkdown
+Suggests: knitr, arules, concaveman, ReactomePA, bnviewer, DESeq2, GEOquery, rmarkdown, withr
 biocViews: Visualization, Bayesian, GeneExpression, NetworkInference, Pathways, Reactome, Network
 VignetteBuilder: knitr
 RoxygenNote: 7.1.2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+PKGNAME := $(shell sed -n "s/Package: *\([^ ]*\)/\1/p" DESCRIPTION)
+PKGVERS := $(shell sed -n "s/Version: *\([^ ]*\)/\1/p" DESCRIPTION)
+PKGSRC  := $(shell basename `pwd`)
+
+all: rd check1 clean
+
+rd:
+	Rscript -e 'library(methods);devtools::document()'
+
+readme:
+	Rscript -e 'rmarkdown::render("README.Rmd", encoding="UTF-8")'
+
+build1:
+	Rscript -e 'devtools::build()'
+
+build2:
+	Rscript -e 'devtools::build(vignettes = FALSE)'
+
+install:
+	cd ..;\
+	R CMD INSTALL $(PKGNAME)_$(PKGVERS).tar.gz
+
+check1: rd build1
+	cd ..;\
+	Rscript -e 'rcmdcheck::rcmdcheck("$(PKGNAME)_$(PKGVERS).tar.gz")'
+
+crancheck: rd build1
+	cd ..;\
+	Rscript -e 'rcmdcheck::rcmdcheck("$(PKGNAME)_$(PKGVERS).tar.gz", args="--as-cran")'
+
+bioccheck:
+	cd ..;\
+	Rscript -e 'BiocCheck::BiocCheck("$(PKGNAME)_$(PKGVERS).tar.gz")'
+
+debug: rd build1
+	cd ..;\
+	R CMD INSTALL $(PKGNAME)_$(PKGVERS).tar.gz
+
+vignettes:
+	Rscript -e 'usethis::use_vignette("$(PKGNAME)")'
+	
+clean:
+	cd ..;\
+	$(RM) -r $(PKGNAME).Rcheck/
+
+clean2:
+	cd ..;\
+	$(RM) $(PKGNAME)_$(PKGVERS).tar.gz
+
+bignore:
+	Rscript -e 'usethis::use_build_ignore(glob2rx("inst/extdata/*.png"), escape = FALSE)'
+	Rscript -e 'usethis::use_build_ignore(c("Makefile", "README.md", "README.Rmd", "CONDUCT.md", ".Rproj.user", ".Rproj"))'
+
+gignore:
+	Rscript -e 'usethis::use_git_ignore(c(".DS_Store", ".RData", ".Rhistory", ".Rproj.user"))'
+
+biocinit:
+	git remote add upstream git@git.bioconductor.org:packages/$(PKGNAME).git;\
+	git fetch --all

--- a/R/bngeneplotCustom.R
+++ b/R/bngeneplotCustom.R
@@ -80,7 +80,9 @@ bngeneplotCustom <- function (results, exp, expSample=NULL, algo="hc", R=20,
     # } else {
     #     resultsGeneType <- results@keytype
     # }
-    results <- setReadable(results, OrgDb=orgDb)
+    if (!is.null(orgDb)){
+        results <- setReadable(results, OrgDb=orgDb)
+    }
     tmpCol <- colnames(results@result)
     tmpCol[tmpCol=="core_enrichment"] <- "geneID"
     tmpCol[tmpCol=="qvalues"] <- "qvalue"
@@ -109,14 +111,20 @@ bngeneplotCustom <- function (results, exp, expSample=NULL, algo="hc", R=20,
     res <- results@result
 
     genesInPathway <- unlist(strsplit(res[pathNum, ]$geneID, "/"))
-    genesInPathway <- clusterProfiler::bitr(genesInPathway,
-                                            fromType="SYMBOL",
-                                            toType=expRow,
-                                            OrgDb=org.Hs.eg.db)[expRow][,1]
+    if (!is.null(orgDb)){
+        genesInPathway <- clusterProfiler::bitr(genesInPathway,
+                                                fromType="SYMBOL",
+                                                toType=expRow,
+                                                OrgDb=orgDb)[expRow][,1]
+    }
     pcs <- exp[ intersect(rownames(exp), genesInPathway), expSample ]
 
     if (convertSymbol) {
-      matchTable <- clusterProfiler::bitr(rownames(pcs), fromType=expRow, toType="SYMBOL", OrgDb=org.Hs.eg.db)
+      if (!is.null(orgDb)){
+          matchTable <- clusterProfiler::bitr(rownames(pcs), fromType=expRow, toType="SYMBOL", OrgDb=orgDb)
+      }else{
+          matchTable <- rownames(pcs)
+      }
       if (sum(duplicated(matchTable[,1])) >= 1) {
         message("Removing expRow that matches the multiple symbols")
         matchTable <- matchTable[!matchTable[,1] %in% matchTable[,1][duplicated(matchTable[,1])],]

--- a/R/bnpathplot.R
+++ b/R/bnpathplot.R
@@ -79,7 +79,9 @@ bnpathplot <- function (results, exp, expSample=NULL, algo="hc", algorithm.args=
             } else if (attributes(results[[i]])$class[1]=="gseaResult"){
                 typeOfOntologies[[i]]=results[[i]]@setType
             }
-            results[[i]] <- setReadable(results[[i]], OrgDb = orgDb)
+            if (!is.null(orgDb)){
+                results[[i]] <- setReadable(results[[i]], OrgDb = orgDb)
+            }
         }
     } else {
         if (attributes(results)$class[1]=="enrichResult"){
@@ -87,7 +89,9 @@ bnpathplot <- function (results, exp, expSample=NULL, algo="hc", algorithm.args=
         } else if (attributes(results)$class[1]=="gseaResult"){
             typeOfOntology=results@setType
         }
-        results <- setReadable(results, OrgDb = orgDb)
+        if (!is.null(orgDb)){
+            results <- setReadable(results, OrgDb = orgDb)
+        }
     }
 
     if (length(results)>1){
@@ -202,11 +206,12 @@ bnpathplot <- function (results, exp, expSample=NULL, algo="hc", algorithm.args=
         if (sizeDep) {
             pathDep = c(pathDep, -1 * mean((filteredDep %>% filter(gene_name %in% genesInPathway))$dependency))
         }
-
-        genesInPathway <- suppressMessages(clusterProfiler::bitr(genesInPathway,
-                                                fromType="SYMBOL",
-                                                toType=expRow,
-                                                OrgDb=org.Hs.eg.db)[expRow][,1])
+        if (!is.null(orgDb)){
+            genesInPathway <- suppressMessages(clusterProfiler::bitr(genesInPathway,
+                                                    fromType="SYMBOL",
+                                                    toType=expRow,
+                                                    OrgDb=orgDb)[expRow][,1])
+        }
         pathwayMatrix <- exp[ intersect(rownames(exp), genesInPathway), expSample ]
         if (dim(pathwayMatrix)[1]==0) {
             message("no gene in the pathway present in expression data")

--- a/R/bnpathplot.R
+++ b/R/bnpathplot.R
@@ -45,7 +45,7 @@
 #' @param shadowText whether to use shadow text for the better readability (default: TRUE)
 #' @param bgColor color for text background when shadowText is TRUE
 #' @param textColor color for text when shadowText is TRUE
-#'
+#' @param seed A random seed to make the analysis reproducible, default is 1.
 #' @return ggplot2 object
 #'
 #' @import ggraph ggplot2 patchwork igraph org.Hs.eg.db enrichplot ExperimentHub Rmpfr
@@ -68,7 +68,7 @@ bnpathplot <- function (results, exp, expSample=NULL, algo="hc", algorithm.args=
                       labelSize=4, layout="nicely", onlyDf=FALSE, disc=FALSE, tr=NULL, remainCont=NULL,
                       shadowText=TRUE, bgColor="white", textColor="black",
                       compareRef=FALSE, strThresh=NULL, strType="normal", hub=NULL, scoreType="bic-g", databasePal="Set2",
-                      dep=NULL, sizeDep=FALSE, orgDb=org.Hs.eg.db, edgeLink=TRUE, cellLineName="5637_URINARY_TRACT", strengthPlot=FALSE, nStrength=10)
+                      dep=NULL, sizeDep=FALSE, orgDb=org.Hs.eg.db, edgeLink=TRUE, cellLineName="5637_URINARY_TRACT", strengthPlot=FALSE, nStrength=10, seed = 1)
 {
     # Set type of ontology and rename
     if (length(results)>1){
@@ -254,9 +254,9 @@ bnpathplot <- function (results, exp, expSample=NULL, algo="hc", algorithm.args=
     }
 
     if (strType == "normal"){
-      strength <- boot.strength(pcs, algorithm=algo, algorithm.args=algorithm.args, R=R, cluster=cl)
+      strength <- withr::with_seed(seed = seed ,boot.strength(pcs, algorithm=algo, algorithm.args=algorithm.args, R=R, cluster=cl))
     } else if (strType == "ms"){
-      strength <- inferMS(pcs, algo=algo, algorithm.args=algorithm.args, R=R, cl=cl)
+      strength <- withr::with_seed(seed = seed, inferMS(pcs, algo=algo, algorithm.args=algorithm.args, R=R, cl=cl))
     }
 
     

--- a/R/bnpathplotCustom.R
+++ b/R/bnpathplotCustom.R
@@ -84,7 +84,9 @@ bnpathplotCustom <- function (results, exp, expSample=NULL, algo="hc", R=20, exp
     } else if (attributes(results)$class[1]=="gseaResult"){
         typeOfOntology=results@setType
     }
-    results <- setReadable(results, OrgDb = orgDb)
+    if (!is.null(orgDb)){
+        results <- setReadable(results, OrgDb = orgDb)
+    }
 
     tmpCol <- colnames(results@result)
     ## Make comparable
@@ -122,12 +124,12 @@ bnpathplotCustom <- function (results, exp, expSample=NULL, algo="hc", R=20, exp
         if (sizeDep){
             pathDep = c(pathDep, -1 * mean((filteredDep %>% filter(gene_name %in% genesInPathway))$dependency))
         }
-
-        genesInPathway <- clusterProfiler::bitr(genesInPathway,
-                                                fromType="SYMBOL",
-                                                toType=expRow,
-                                                OrgDb=org.Hs.eg.db)[expRow][,1]
-
+        if (!is.null(orgDb)){
+            genesInPathway <- clusterProfiler::bitr(genesInPathway,
+                                                    fromType="SYMBOL",
+                                                    toType=expRow,
+                                                    OrgDb=orgDb)[expRow][,1]
+        }
         pathwayMatrix <- exp[ intersect(rownames(exp), genesInPathway), expSample ]
         if (dim(pathwayMatrix)[1]==0) {
             message("no gene in the pathway present in expression data")

--- a/R/bnpathplotCustom.R
+++ b/R/bnpathplotCustom.R
@@ -50,7 +50,7 @@
 #' @param otherVarName the names of other variables
 #' @param onlyDf return only data.frame used for inference
 #' @param orgDb perform clusterProfiler::setReadable based on this organism database
-#'
+#' @param seed A random seed to make the analysis reproducible, default is 1.
 #' @examples 
 #' data("exampleEaRes");data("exampleGeneExp")
 #' res <- bnpathplotCustom(results=exampleEaRes, exp=exampleGeneExp, fontFamily="sans", glowEdgeNum=3, hub=3)
@@ -67,7 +67,7 @@ bnpathplotCustom <- function (results, exp, expSample=NULL, algo="hc", R=20, exp
                              strengthPlot=FALSE, nStrength=10, strThresh=NULL, hub=NULL, glowEdgeNum=NULL,
                              nodePal=c("blue","red"), edgePal=c("blue","red"), textCol="black", backCol="white",
                              barTextCol="black", barPal=c("red","blue"), barBackCol="white", scoreType="bic-g",
-                             barLegendKeyCol="white", orgDb=org.Hs.eg.db, barAxisCol="black", barPanelGridCol="black") {
+                             barLegendKeyCol="white", orgDb=org.Hs.eg.db, barAxisCol="black", barPanelGridCol="black", seed = 1) {
     # if (is.null(hub) || is.null(glowEdgeNum) || hub <= 0 || glowEdgeNum <= 0) {stop("please specify number >= 1 for hub, glowEdgeNum")}
     if (length(nodePal)!=2 || length(edgePal)!=2 || length(barPal)!=2){stop("Please pick two colors for nodePal, edgePal and barPal.")}
     if (compareRef){stop("compareRef is currently not supported.")}
@@ -168,9 +168,9 @@ bnpathplotCustom <- function (results, exp, expSample=NULL, algo="hc", R=20, exp
     }
 
     if (strType == "normal"){
-      strength <- boot.strength(pcs, algorithm=algo, algorithm.args=algorithm.args, R=R, cluster=cl)
+      strength <- withr::with_seed(seed = seed, boot.strength(pcs, algorithm=algo, algorithm.args=algorithm.args, R=R, cluster=cl))
     } else if (strType == "ms"){
-      strength <- inferMS(pcs, algo=algo, algorithm.args=algorithm.args, R=R, cl=cl)
+      strength <- withr::with_seed(seed = seed, inferMS(pcs, algo=algo, algorithm.args=algorithm.args, R=R, cl=cl))
     }
 
     if (strengthPlot){

--- a/man/bngeneplot.Rd
+++ b/man/bngeneplot.Rd
@@ -49,7 +49,8 @@ bngeneplot(
   strengthPlot = FALSE,
   nStrength = 10,
   strThresh = NULL,
-  hub = NULL
+  hub = NULL,
+  seed = 1
 )
 }
 \arguments{
@@ -142,6 +143,8 @@ bngeneplot(
 \item{strThresh}{the threshold for strength}
 
 \item{hub}{visualize the genes with top-n hub scores}
+
+\item{seed}{A random seed to make the analysis reproducible, default is 1.}
 }
 \value{
 ggplot2 object

--- a/man/bngeneplotCustom.Rd
+++ b/man/bngeneplotCustom.Rd
@@ -51,7 +51,8 @@ bngeneplotCustom(
   barLegendKeyCol = "white",
   barAxisCol = "black",
   barPanelGridCol = "black",
-  titleSize = 24
+  titleSize = 24,
+  seed = 1
 )
 }
 \arguments{
@@ -148,6 +149,8 @@ bngeneplotCustom(
 \item{barPanelGridCol}{panel grid color in barplot}
 
 \item{titleSize}{the size of title}
+
+\item{seed}{A random seed to make the analysis reproducible, default is 1.}
 }
 \value{
 ggplot2 object

--- a/man/bnpathplot.Rd
+++ b/man/bnpathplot.Rd
@@ -47,7 +47,8 @@ bnpathplot(
   edgeLink = TRUE,
   cellLineName = "5637_URINARY_TRACT",
   strengthPlot = FALSE,
-  nStrength = 10
+  nStrength = 10,
+  seed = 1
 )
 }
 \arguments{
@@ -136,6 +137,8 @@ bnpathplot(
 \item{strengthPlot}{append the barplot depicting edges with high strength}
 
 \item{nStrength}{specify how many edges are included in the strength plot}
+
+\item{seed}{A random seed to make the analysis reproducible, default is 1.}
 }
 \value{
 ggplot2 object

--- a/man/bnpathplotCustom.Rd
+++ b/man/bnpathplotCustom.Rd
@@ -52,7 +52,8 @@ bnpathplotCustom(
   barLegendKeyCol = "white",
   orgDb = org.Hs.eg.db,
   barAxisCol = "black",
-  barPanelGridCol = "black"
+  barPanelGridCol = "black",
+  seed = 1
 )
 }
 \arguments{
@@ -151,6 +152,8 @@ bnpathplotCustom(
 \item{barAxisCol}{axis color in barplot}
 
 \item{barPanelGridCol}{panel grid color in barplot}
+
+\item{seed}{A random seed to make the analysis reproducible, default is 1.}
 }
 \value{
 ggplot2 object


### PR DESCRIPTION
+ The `clusterProfiler` provided a universal enrichment function `enricher`, which was inherited by the `MicrobiomeProfiler`. But the original functions of `CBNplot`  do not support the results. This `PR` fixes the problem by setting `orgDb` to `NULL`.

```
library(MicrobiomeProfiler)
data(Rat_data)
ko.res <- enrichKO(Rat_data)
exp.dat <- matrix(abs(rnorm(910)), 91, 10) %>% magrittr::set_rownames(value=Rat_data) %>% magrittr::set_colnames(value=paste0('S', seq_len(ncol(.))))
exp.dat %>% head
library(CBNplot)
bngeneplot(ko.res, exp=exp.dat, pathNum=1, orgDb=NULL)
```
![xx](https://user-images.githubusercontent.com/17870644/160403608-0c202b8c-3bfe-476e-9809-f6f48bcefa83.PNG)
